### PR TITLE
Weapon damage modifiers

### DIFF
--- a/module/actor/actor-degenesis.js
+++ b/module/actor/actor-degenesis.js
@@ -1,7 +1,7 @@
-import { DEGENESIS } from "../config.js";
-import { DEG_Utility } from "../utility.js";
-import { DegenesisDice } from "../dice.js";
-import { DegenesisItem } from "../item/item-degenesis.js";
+import {DEGENESIS} from "../config.js";
+import {DEG_Utility} from "../utility.js";
+import {DegenesisDice} from "../dice.js";
+import {DegenesisItem} from "../item/item-degenesis.js";
 
 /**
  * Extend the basic ActorSheet with some very simple modifications
@@ -382,6 +382,7 @@ export class DegenesisActor extends Actor {
             weapon.farDice = weapon.effectiveDice - 4 > 0  ? weapon.effectiveDice - 4 : 0 
             weapon.extremeDice = weapon.effectiveDice - 8 > 0  ? weapon.effectiveDice - 8 : 0 
         }
+        weapon.damageFormula = DegenesisItem.damageFormula(weapon.data);
 
         return weapon
     }
@@ -492,6 +493,11 @@ export class DegenesisActor extends Actor {
         let {dialogData, cardData, rollData} = this.setupWeapon(weapon)
         rollData = await DegenesisDice.showRollDialog({dialogData, rollData})
         let rollResults = await DegenesisDice.rollAction(rollData)
+        const bodyValue = this.data.data.attributes.body.value;
+        const forceValue = this.data.data.skills.force.value;
+        const bodyForceValue = bodyValue + forceValue;
+        const fullDamage = DegenesisItem.fullDamage(weapon.data, bodyForceValue, rollResults.triggers);
+        cardData.damageFull = `${fullDamage}`;
         rollResults.weapon = rollData.weapon
         if (rollData.weapon.isRanged)
             this.updateEmbeddedEntity("OwnedItem", {_id : rollData.weapon._id, "data.mag.current" : rollData.weapon.data.mag.current - 1})

--- a/module/config.js
+++ b/module/config.js
@@ -490,6 +490,13 @@ DEGENESIS.armorQualityDescription = {
   "sealed" : "DGNS.SealedDescription",
 }
 
+DEGENESIS.damageModifiers = {
+  "F": {blueprint: "+F", calculate: (force, triggers) => force},
+  "F2": {blueprint: "+F/2", calculate: (force, triggers) => Math.ceil(force / 2)},
+  "F3": {blueprint: "+F/3", calculate: (force, triggers) => Math.ceil(force / 3)},
+  "T": {blueprint: "+T", calculate: (force, triggers) => triggers},
+}
+
 DEGENESIS.techValues = {
   1 : "I",
   2 : "II",

--- a/module/item/item-degenesis.js
+++ b/module/item/item-degenesis.js
@@ -90,7 +90,7 @@ export class DegenesisItem extends Item {
         /*tags.push(`TECH: ${DEGENESIS.techValues[data.tech]}`)*/
         /*tags.push(`SLOTS: ${data.slots.used}/${data.slots.total}`)*/
         tags.push(`${game.i18n.localize("DGNS.Handling")}: ${data.handling}D`)
-        tags.push(`${game.i18n.localize("DGNS.Damage")}: ${data.damage}`)
+        tags.push(`${game.i18n.localize("DGNS.Damage")}: ${DegenesisItem.damageFormula(data)}`)
         tags.push(`${game.i18n.localize("DGNS.Distance")}: ${DegenesisItem.isMelee(this.data) ? data.distance.melee : `${data.distance.short} / ${data.distance.far}` }`)
         if(DegenesisItem.isMelee(this.data)==false){tags.push(data.mag.belt ? `${game.i18n.localize("DGNS.Magazine")}: ${game.i18n.localize("DGNS.Belt")}` : `${game.i18n.localize("DGNS.Magazine")}: ${data.mag.size}`)};
         tags.push(`${game.i18n.localize("DGNS.Value")}: ${data.value}`)
@@ -145,7 +145,7 @@ export class DegenesisItem extends Item {
             tags : tags        
         }
     }
-    static isMelee(data) 
+    static isMelee(data)
     {
         if (data.type = "weapon")
             return DEGENESIS.weaponGroupSkill[data.data.group] == "projectiles" || data.data.group =="sonic" ? false : true 
@@ -162,6 +162,30 @@ export class DegenesisItem extends Item {
     {
         if (data.type = "weapon")
             return data.data.group == "sonic" 
+    }
+
+    static damageFormula(weaponData) {
+        const baseDamage = `${weaponData.damage}`;
+        if (!weaponData.damageBonus) {
+            return baseDamage;
+        }
+        const damageModifier = DEGENESIS.damageModifiers[weaponData.damageBonus];
+        if (!damageModifier) {
+            return baseDamage;
+        }
+        return baseDamage + damageModifier.blueprint;
+    }
+
+    static fullDamage(weaponData, force, triggers) {
+        const baseValue = parseInt(weaponData.damage);
+        if (!weaponData.damageBonus) {
+            return baseValue;
+        }
+        const damageModifier = DEGENESIS.damageModifiers[weaponData.damageBonus];
+        if (!damageModifier) {
+            return baseValue;
+        }
+        return baseValue + damageModifier.calculate(force, triggers);
     }
 
     static matchAmmo(weapon, ammo)

--- a/module/item/item-sheet.js
+++ b/module/item/item-sheet.js
@@ -51,6 +51,10 @@ export class DegenesisItemSheet extends ItemSheet {
       data.weaponGroups = DEGENESIS.weaponGroups;
       data.calibers = DEGENESIS.calibers;
     }
+    if (data.item.type == "weapon" || data.item.type == "ammunition")
+    {
+      data.damageModifiers = DEGENESIS.damageModifiers;
+    }
     if (data.item.type == "equipment")
     {
       data.equipmentGroups = DEGENESIS.equipmentGroups;

--- a/styles/degenesis.css
+++ b/styles/degenesis.css
@@ -1674,15 +1674,15 @@ padding-right: 4px;
     flex: 0.25;
 }
 
-.app.window-app.degenesis.sheet .arsenal-list .legend-name.dammage {
+.app.window-app.degenesis.sheet .arsenal-list .legend-name.damage {
     flex: 1;
 }
 
-.app.window-app.degenesis.sheet .arsenal-list .legend-name.dammage-ranged {
+.app.window-app.degenesis.sheet .arsenal-list .legend-name.damage-ranged {
 }
 
 
-.app.window-app.degenesis.sheet .arsenal-list .legend-name.dammage-ranged-sonic {
+.app.window-app.degenesis.sheet .arsenal-list .legend-name.damage-ranged-sonic {
     flex: 1;
 }
 
@@ -2236,7 +2236,7 @@ margin-left: 12px;
     
 }
 
-.app.window-app.degenesis.sheet.item .detail-container select.cac-select{
+.app.window-app.degenesis.sheet.item .detail-container select.damageBonus-select{
     width: auto;
     flex: 1;
 }

--- a/template.json
+++ b/template.json
@@ -383,11 +383,13 @@
     }
   },
   "ammunition" : {
-    "templates": ["description", "quantity", "damage", "tech", "value"]
+    "templates": ["description", "quantity", "damage", "tech", "value"],
+    "damageBonus": ""
   },
   "weapon" : {
     "templates" : ["description", "equipped", "quantity", "damage", "qualities", "encumbrance", "tech", "slots", "value", "resources", "cult"],
     "handling": 0,
+    "damageBonus": "",
     "distance": {
       "short" : 0,
       "far" : 0,

--- a/templates/actor/actor-combat.html
+++ b/templates/actor/actor-combat.html
@@ -164,7 +164,7 @@
                </div>
                <div class="legend-name empty-melee">
                </div>
-               <div class="legend-name dammage">
+               <div class="legend-name damage">
                   <span>{{localize "DGNS.Damage"}}</span>
                </div>
                <div class="legend-name distance">
@@ -182,8 +182,8 @@
                </div>
                <div class="legend-name empty-melee">
                </div>
-               <div class="legend-name dammage">
-                  <span>{{weapon.data.damage}}</span>
+               <div class="legend-name damage">
+                  <span>{{weapon.damageFormula}}</span>
                </div>
                <div class="legend-name distance">
                   <span>{{weapon.data.distance.melee}}</span>
@@ -236,7 +236,7 @@
                <div class="legend-name magazine">
                   <span>{{localize "DGNS.Magazine"}}</span>
                </div>
-               <div class="legend-name dammage">
+               <div class="legend-name damage">
                   <span>{{localize "DGNS.Damage"}}</span>
                </div>
                <div class="legend-name distance">
@@ -255,8 +255,8 @@
                <div class="legend-name magazine-ranged" title="{{localize 'DGNS.TotalAmmo'}}: {{weapon.totalAvailableAmmo}}">
                   <a class="mag-count reload-click">{{weapon.data.mag.current}}</a><span>/{{weapon.data.mag.size}}</span> ({{weapon.caliber}})
                </div>
-               <div class="legend-name dammage-ranged">
-                  <span>{{weapon.data.damage}}</span>
+               <div class="legend-name damage-ranged">
+                  <span>{{weapon.damageFormula}}</span>
                </div>
                <div class="legend-name distance-ranged">
                   <span>{{weapon.data.distance.short}}/{{weapon.data.distance.far}}</span>
@@ -310,7 +310,7 @@
                <div class="legend-name magazine">
                   <span>{{localize "DGNS.Magazine"}}</span>
                </div>
-               <div class="legend-name dammage">
+               <div class="legend-name damage">
                   <span>{{localize "DGNS.Damage"}}</span>
                </div>
                <div class="legend-name distance">
@@ -329,8 +329,8 @@
                <div class="legend-name magazine-ranged-sonic">
                   <a class="mag-count">10</a><span>/{{weapon.data.mag.size}}</span>
                </div>
-               <div class="legend-name dammage-ranged-sonic">
-                  <span>{{weapon.data.damage}}</span>
+               <div class="legend-name damage-ranged-sonic">
+                  <span>{{weapon.damageFormula}}</span>
                </div>
                <div class="legend-name distance-ranged-sonic">
                   <span>{{weapon.data.distance.melee}}</span>

--- a/templates/chat/weapon-roll-card.html
+++ b/templates/chat/weapon-roll-card.html
@@ -1,3 +1,3 @@
 {{> systems/degenesis/templates/chat/roll-card.html }}
 
-<div>Damage: {{weapon.data.damage}}</div>
+<div>Damage: {{damageFull}}</div>

--- a/templates/item/item-ammunition-sheet.html
+++ b/templates/item/item-ammunition-sheet.html
@@ -64,12 +64,13 @@
                     <span class="field-name">{{localize "DGNS.Damage"}}: </span>
                     <div class="field-inputs">
                         <input class="field-input field-start" type="text" name="data.damage" value="{{data.damage}}" data-dtype="Number"/>
-                        <select class="cac-select" name="data.cac" data-dtype="String">
+                        <select class="damageBonus-select" name="data.damageBonus" data-dtype="String">
                             <option value=""></option>
-                            <option value="F">+ F</option>
-                            <option value="F/2">+ F/2</option>
-                            <option value="F/3">+ F/3</option>
-                            <option value="T">+ T</option>
+                            {{#select data.damageBonus}}
+                            {{#each damageModifiers as |modifier bonus|}}
+                            <option value="{{bonus}}">{{modifier.blueprint}}</option>
+                            {{/each}}
+                            {{/select}}
                         </select>
                     </div>
                 </div>

--- a/templates/item/item-weapon-sheet.html
+++ b/templates/item/item-weapon-sheet.html
@@ -64,12 +64,13 @@
                     <span class="field-name">{{localize "DGNS.Damage"}}: </span>
                     <div class="field-inputs">
                         <input class="field-input field-start" type="text" name="data.damage" value="{{data.damage}}" data-dtype="Number"/>
-                        <select class="cac-select" name="data.cac" data-dtype="String">
+                        <select class="damageBonus-select" name="data.damageBonus" data-dtype="String">
                             <option value=""></option>
-                            <option value="F">+ F</option>
-                            <option value="F/2">+ F/2</option>
-                            <option value="F/3">+ F/3</option>
-                            <option value="T">+ T</option>
+                            {{#select data.damageBonus}}
+                            {{#each damageModifiers as |modifier bonus|}}
+                            <option value="{{bonus}}">{{modifier.blueprint}}</option>
+                            {{/each}}
+                            {{/select}}
                         </select>
                     </div>
                 </div>


### PR DESCRIPTION
Use of BOD+Force or Triggers as extra damage, for example 4+F/2. Weapons can now have such damage modifiers and the damage calculations now include those bonuses during combat attacks.