### PR TITLE
mark attribute as focus or primal

### DIFF
--- a/module/actor/actor-sheet.js
+++ b/module/actor/actor-sheet.js
@@ -99,10 +99,13 @@ export class DegenesisActorSheet extends ActorSheet {
     sortAttributesSkillsDiamonds() {
         let attributeSkillGroups = this.sortAttributesSkills()
 
+        const isFocus = !!attributeSkillGroups.intellect.skills.focus.value;
+        const type = isFocus ? DEGENESIS.skills['focus'] : DEGENESIS.skills['primal'];
+
         for (let attrKey in attributeSkillGroups) {
             let attrGroup = attributeSkillGroups[attrKey]
             DEG_Utility.addDiamonds(attrGroup, 6)
-
+            DEG_Utility.addAttributeType(attrGroup, attrKey, type);
             for (let skillKey in attrGroup.skills) {
                 DEG_Utility.addDiamonds(attrGroup.skills[skillKey], 6)
 

--- a/module/config.js
+++ b/module/config.js
@@ -124,6 +124,15 @@ DEGENESIS.attributeAbbrev = {
   "instinct" : "DGNS.InstinctAbbrev",
 }
 
+DEGENESIS.attributeType = {
+  "body" :  "DGNS.Primal",
+  "agility" :  "DGNS.Focus",
+  "charisma" :  "DGNS.Primal",
+  "intellect" :  "DGNS.Focus",
+  "psyche" :  "DGNS.Focus",
+  "instinct" : "DGNS.Primal",
+}
+
 DEGENESIS.skills = {
   "athletics" : "DGNS.Athletics",
   "brawl" : "DGNS.Brawl",

--- a/module/utility.js
+++ b/module/utility.js
@@ -30,6 +30,14 @@ export class DEG_Utility {
         return data
     }
 
+    static addAttributeType(data, attribute, condition){
+        const currentType = DEGENESIS.attributeType[attribute];
+
+        data.isPreferred = currentType === condition;
+
+        return data;
+    }
+    
     static getModificationActions()
     {
         let actions = foundry.utils.deepClone(DEGENESIS.modifyActions);

--- a/templates/actor/actor-attributes-skills-diamonds.html
+++ b/templates/actor/actor-attributes-skills-diamonds.html
@@ -22,6 +22,9 @@
          <!-- black-title -->
          <div class="attribute-name">
             <h3>{{group.label}}</h3>
+            {{#if group.isPreferred}}
+            <h3>•</h3>
+            {{/if}}
          </div>
          
          <div class = "diamond-row" data-target="data.attributes.{{g}}.value">


### PR DESCRIPTION
The base idea of this is to show up which attributes are Focus and which ones are Primal.

Depending on your selection, a dot will appear next to your chosen attributes, clearly indicating which set of attributes are focus and primal.

Example here!
![focus](https://user-images.githubusercontent.com/31822629/120397165-b4da0b80-c32f-11eb-90a9-d98cf6c539ba.png)
