### PR TITLE
add showName property to display name on conditions

### DIFF
--- a/lang/de.json
+++ b/lang/de.json
@@ -127,6 +127,7 @@
   "DGNS.PassiveDef": "Passive Verteidigung",
   "DGNS.DropBackpack": "Rucksack fallen lassen",
   "DGNS.InMotion": "In Bewegung",
+  "DGNS.ShowName": "Name anzeigen",
   "DGNS.ActiveAndOnMyFeet": "Aktiv und auf den Füßen",
   "DGNS.Cover": "Deckung",
   "DGNS.SpendEgo": "Ego ausgeben",

--- a/lang/en.json
+++ b/lang/en.json
@@ -135,6 +135,7 @@
     "DGNS.PassiveDef" : "Passive Defense",
     "DGNS.DropBackpack" : "Drop Backpack",
     "DGNS.InMotion" : "In Motion",
+    "DGNS.ShowName": "Show Name",
     "DGNS.ActiveAndOnMyFeet" : "Active And On My Feet",
     "DGNS.Cover" : "Cover",
     "DGNS.SpendEgo" : "Spend Ego",

--- a/lang/es.json
+++ b/lang/es.json
@@ -111,6 +111,7 @@
     "DGNS.PassiveDef": "Defensa Pasiva",
     "DGNS.DropBackpack": "Soltar Mochila",
     "DGNS.InMotion": "En Movimiento",
+    "DGNS.ShowName": "Mostrar Nombre",
     "DGNS.ActiveAndOnMyFeet": "Activo y de Pie",
     "DGNS.Cover": "Cobertura",
     "DGNS.SpendEgo": "Gastar Ego",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -112,6 +112,7 @@
     "DGNS.PassiveDef" : "Défense Passive",
     "DGNS.DropBackpack" : "Equipem. lâché",
     "DGNS.InMotion" : "En mouvement",
+    "DGNS.ShowName": "Afficher le nom",
     "DGNS.ActiveAndOnMyFeet" : "Actif et debout",
     "DGNS.Cover" : "Couverture",
     "DGNS.SpendEgo" : "Dépense Ego",

--- a/module/item/item-degenesis.js
+++ b/module/item/item-degenesis.js
@@ -451,6 +451,7 @@ export class DegenesisItem extends Item {
     get mode() { return this.data.data.mode }
     get modifyType() { return this.data.data.type }
     get modifyNumber() { return this.data.data.number }
+    get modifyShowName() { return this.data.data.showName}
     get origin() { return this.data.data.origin }
     get prerequisite() { return this.data.data.prerequisite }
     get qualities() { return this.data.data.qualities }

--- a/template.json
+++ b/template.json
@@ -218,6 +218,7 @@
     },
     "condition": {
       "condition" : {
+        "showName": false,
         "ego": {
           "max": 0,
           "value": 0,
@@ -464,7 +465,8 @@
     "action" : "",
     "number" : 0,
     "type" : "",
-    "disabled" : false
+    "disabled" : false,
+    "showName": false
   },
   "complication" : {
     "cost" : 0,

--- a/template.json
+++ b/template.json
@@ -465,8 +465,7 @@
     "action" : "",
     "number" : 0,
     "type" : "",
-    "disabled" : false,
-    "showName": false
+    "disabled" : false
   },
   "complication" : {
     "cost" : 0,

--- a/template.json
+++ b/template.json
@@ -218,7 +218,6 @@
     },
     "condition": {
       "condition" : {
-        "showName": false,
         "ego": {
           "max": 0,
           "value": 0,
@@ -465,7 +464,8 @@
     "action" : "",
     "number" : 0,
     "type" : "",
-    "disabled" : false
+    "disabled" : false,
+    "showName": false
   },
   "complication" : {
     "cost" : 0,

--- a/templates/actor/actor-condition.html
+++ b/templates/actor/actor-condition.html
@@ -135,10 +135,14 @@
                            <a class="modifiers-number dropdown">{{mod.ModifyNumber}}</a>
                            <a class="modifiers-type dropdown">{{mod.ModifyType}}</a>
                         </div>
-                        {{#if (eq mod.action "custom")}}
-                        <a class="modifiers-action dropdown">{{mod.name}}</a>
+                        {{#if mod.modifyShowName }}
+                           <a class="modifiers-action dropdown">{{mod.name}}</a>
                         {{else}}
-                        <a class="modifiers-action dropdown">{{mod.ActionType}}</a>
+                           {{#if (eq mod.action "custom")}}
+                              <a class="modifiers-action dropdown">{{mod.name}}</a>
+                           {{else}}
+                              <a class="modifiers-action dropdown">{{mod.ActionType}}</a>
+                           {{/if}}
                         {{/if}}
                         <div class="vertical-bar">
                            <svg height="15px" width="1px">

--- a/templates/item/item-modifier-sheet.html
+++ b/templates/item/item-modifier-sheet.html
@@ -55,5 +55,15 @@
             <textarea name="data.description">{{data.description}}</textarea>
         </div>
         {{/if}}
+
+        <div class="form-group">
+            <label>{{localize "DGNS.ShowName"}}</label>
+            <select name="data.showName">
+                {{#select data.showName}}
+                <option value="">✘</option>
+                <option value="true">✔</option>
+                {{/select}}
+            </select>
+        </div>
     </section>
 </form>


### PR DESCRIPTION

This is relatively easy but it can surely help people who has a lot of conditions! Knowing the action that it's been modified helps, but knowing the name should help even more.

All in all, this PR adds a new property to the conditions, `showName`, that if enabled, will show the name of the condition instead of the action. You can see the design on the attached screen!

I've added the corresponding locales in all the four supported languages, and this should work without much fuss! In order to prevent the need of adding even more locales, I've resorted into using ascii icons for the false and true conditions; it should work like a charm!

And of course, by default it works as of now, so this can be safely toggled depending on the case!

![screen1](https://user-images.githubusercontent.com/31822629/121807805-9c31f580-cc4d-11eb-98a0-225967006365.png)
