### PR TITLE
Encumbrance Action Modifier & Current Mag Size Fix

### DIFF
--- a/module/actor/actor-degenesis.js
+++ b/module/actor/actor-degenesis.js
@@ -69,7 +69,8 @@ export class DegenesisActor extends Actor {
            this.general.encumbrance.max =     this.general.encumbrance.override || (this.attributes.body.value + this.skills.force.value);
 
             this.prepareItems();
-            this.modifiers.addEncumbranceModifiers(this)
+            this.prepareEncumbranceModifiers();
+            
 
             this.general.actionModifier = this.modifiers.action.D
             this.general.movement =        this.attributes.body.value + this.skills.athletics.value + (this.modifiers.movement || 0)
@@ -84,10 +85,29 @@ export class DegenesisActor extends Actor {
             console.error(e);
         }
     }
-     
+  
+    
+    prepareEncumbranceModifiers(){
+        //set variable for difference between current and max encumbrance
+            let encumbranceOver = (this.general.encumbrance.current - this.general.encumbrance.max);
 
-
-
+        // if encumbranceOver is positive (you are over max encumbrance), if it's negative you are below max encumbrance
+        
+            if (encumbranceOver > 0){
+                //fixes the encumbrance modifiers that were previously not being added
+                 this.modifiers.action.D -= encumbranceOver;
+            }
+            else if (encumbranceOver < 0) {
+                // prevents resetting D completely to 0 in case other things affect the action modifiers
+                encumbranceOver = 0
+                this.modifiers.action.D += encumbranceOver;
+            }
+            else {
+                window.alert("You are at max carrying weight, going over will affect your rolls!");
+            }
+    }
+    
+    
     prepareItems() {
 
         let encumbrance = this.general.encumbrance

--- a/module/actor/actor-degenesis.js
+++ b/module/actor/actor-degenesis.js
@@ -96,6 +96,8 @@ export class DegenesisActor extends Actor {
             if (encumbranceOver > 0){
                 //fixes the encumbrance modifiers that were previously not being added
                  this.modifiers.action.D -= encumbranceOver;
+                //repeats warning when you continue to add weight (feel free to remove)
+                 ui.notifications.warn("You are over encumbered!");
             }
             else if (encumbranceOver < 0) {
                 // prevents resetting D completely to 0 in case other things affect the action modifiers

--- a/module/actor/actor-degenesis.js
+++ b/module/actor/actor-degenesis.js
@@ -103,7 +103,7 @@ export class DegenesisActor extends Actor {
                 this.modifiers.action.D += encumbranceOver;
             }
             else {
-                window.alert("You are at max carrying weight, going over will affect your rolls!");
+                ui.notifications.warn("You are over encumbered!");
             }
     }
     
@@ -332,7 +332,7 @@ export class DegenesisActor extends Actor {
         }
         // notifies player that mag is empty and returns null to prevent mag size from going below 0
         else {
-            window.alert("Mag is empty);
+            ui.notifications.warn("Mag is empty");
             return null;
         }
     }

--- a/module/actor/actor-degenesis.js
+++ b/module/actor/actor-degenesis.js
@@ -323,10 +323,18 @@ export class DegenesisActor extends Actor {
 
         const fullDamage = weapon.fullDamage(rollResults.triggers, { modifier: this.modifiers.damage })
         cardData.damageFull = `${fullDamage}`;
-        if (rollData.weapon.isRanged)
+        
+        //stops current mag size from going below 0
+        if (rollData.weapon.isRanged && rollData.weapon.mag.current > 0){
             this.updateEmbeddedDocuments("Item", [{ _id: rollData.weapon.id, "data.mag.current": rollData.weapon.mag.current - 1 }])
-        this.postRollChecks(rollResults, "weapon")
-        return { rollResults, cardData }
+            this.postRollChecks(rollResults, "weapon")
+            return { rollResults, cardData }
+        }
+        // notifies player that mag is empty and returns null to prevent mag size from going below 0
+        else {
+            window.alert("Mag is empty);
+            return null;
+        }
     }
 
 

--- a/module/modifier-manager.js
+++ b/module/modifier-manager.js
@@ -105,10 +105,12 @@ export default class ModifierManager
         this.a_defense.D = this.a_defense.D ? this.a_defense.D + shieldActiveModifier : shieldActiveModifier
     }
 
+    // not sure why lines 112-115 didnt work, but I added the same functionality for encumbrance modifiers in actor-degenesis.js @ lines 72 &  90-108
 
+    /*
     addEncumbranceModifiers(actor) {
         if (actor.data.encumbrance && (actor.data.encumbrance.current > actor.data.encumbrance.max))
-            this.action.D -= (actor.data.encumbrance.current - actor.data.encumbrance.max)
+            return (actor.data.encumbrance.current - actor.data.encumbrance.max)
     }
 
 


### PR DESCRIPTION
-Fixed the current mag size of a firearm going below 0
-Fixed encumbrance modifiers not being added to action rolls such as initiative, dodging, etc.