### PR TITLE
moving renderRollCard for skill rolls to actor-degenesis.js

### DIFF
--- a/module/actor/actor-degenesis.js
+++ b/module/actor/actor-degenesis.js
@@ -3,6 +3,7 @@ import { DEG_Utility } from "../utility.js";
 import { DegenesisDice } from "../dice.js";
 import { DegenesisItem } from "../item/item-degenesis.js";
 import ModifierManager from "../modifier-manager.js";
+import { DegenesisChat } from "../chat.js";
 
 import { AutomateEncumbrancePenalty } from "../settings.js"
 
@@ -315,8 +316,13 @@ export class DegenesisActor extends Actor {
     //#endregion
 
     //#region Roll Processing
-    async rollSkill(skill, { skipDialog = false }) {
+    async rollSkill(skill, { skipDialog = false, override = {}}) {
         let { dialogData, cardData, rollData } = this.setupSkill(skill)
+
+        for (const key in override) {
+            dialogData[key] = override[key]
+        }
+
         if (!skipDialog)
             rollData = await DegenesisDice.showRollDialog({ dialogData, rollData })
         else {
@@ -331,6 +337,9 @@ export class DegenesisActor extends Actor {
             await this.handleSecondaryRoll({ dialogData, cardData, rollData, rollResults }, this.setupSkill(rollData.secondary))
 
         this.postRollChecks(rollResults, skill)
+
+        DegenesisChat.renderRollCard(rollResults, cardData)
+
         return { rollResults, cardData }
     }
 

--- a/module/actor/actor-sheet.js
+++ b/module/actor/actor-sheet.js
@@ -413,8 +413,7 @@ export class DegenesisActorSheet extends ActorSheet {
     async _onSkillClick(event) {
         let skill = $(event.currentTarget).parents(".skill").attr("data-target")
         let skipDialog = event.ctrlKey
-        let { rollResults, cardData } = await this.actor.rollSkill(skill, { skipDialog })
-        DegenesisChat.renderRollCard(rollResults, cardData)
+        await this.actor.rollSkill(skill, { skipDialog })
     }
     async _onInitiativeClick(event) {
         const tokens = this.actor.isToken ? [this.actor.token] : this.actor.getActiveTokens(true);


### PR DESCRIPTION
Hello! This is a suggested change for rendering the skill roll chat message. These changes came up when I was trying to add DEGENESIS as supported system for the module "Let Me Roll That For You" (LMRTY), but I believe these changes will be useful for other modules as well. 

I moved DegenesisChat.renderRollCard from DegenesisActorSheet to DegenesisActor. The reason why it may be useful to render the chat message directly from the DegenesisActor is for rolling skills without needing to access DegenesisActorSheet. 

I added the other function parameter "override" to rollSkill in order to be able to change the prefilled data dialog. The reason I added this was to be able to set skill roll difficulties when called from outside the DegenesisActorSheet.